### PR TITLE
chore: only release when necessary

### DIFF
--- a/.github/workflows/_check-release-eligibility.yml
+++ b/.github/workflows/_check-release-eligibility.yml
@@ -22,6 +22,7 @@ on:
         value: ${{ jobs.check-release-eligibility.outputs.should-release }}
 
 permissions:
+  contents: read
   pull-requests: read
 
 jobs:
@@ -34,29 +35,33 @@ jobs:
         id: set-output
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_ACCESS_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          IS_RELEASE_BRANCH: ${{ inputs.is-release-branch }}
+          FORCE_RELEASE: ${{ inputs.force-release }}
         run: |
           should_release=false
 
-          if [ "${{ inputs.force-release }}" == "true" ]; then
-            # Force release overrides everything
+          if [ "$FORCE_RELEASE" = "true" ]; then
             should_release=true
-          elif [ "${{ inputs.is-release-branch }}" == "true" ]; then
-            # Get merged PRs since last release tag
-            LAST_TAG=$(gh api repos/${GITHUB_REPOSITORY}/tags --jq '.[0].name' --silent)
-            if [ -z "$LAST_TAG" ]; then
-              RANGE="$GITHUB_SHA"
+          elif [ "$IS_RELEASE_BRANCH" = "true" ]; then
+            # Get last tag
+            LAST_TAG=$(gh api repos/$REPO/tags --jq '.[0].name' --silent)
+
+            if [ -n "$LAST_TAG" ]; then
+              # Get commits between last tag and current SHA
+              COMMITS=$(gh api repos/$REPO/compare/$LAST_TAG...$SHA --jq '.commits[].commit.message' --silent)
             else
-              RANGE="$LAST_TAG..$GITHUB_SHA"
+              # No previous tag, consider all commits
+              COMMITS=$(gh api repos/$REPO/commits?sha=$SHA --jq '.[].commit.message' --silent)
             fi
 
-            # Get commits in range and their associated PRs
-            PRS=$(gh api repos/${GITHUB_REPOSITORY}/commits \
-              -f sha="$GITHUB_SHA" \
-              --jq '.[] | select(.commit.message | test("#[0-9]+")) | .commit.message' \
-              --silent | grep -oE '#[0-9]+' | sort -u | tr -d '#')
+            # Extract PR numbers
+            PRS=$(echo "$COMMITS" | grep -oE '#[0-9]+' | sort -u | tr -d '#')
 
+            # Check labels of each PR
             for pr in $PRS; do
-              LABELS=$(gh api repos/${GITHUB_REPOSITORY}/pulls/$pr --jq '.labels[].name' --silent)
+              LABELS=$(gh api repos/$REPO/pulls/$pr --jq '.labels[].name' --silent)
               if ! echo "$LABELS" | grep -q "no-release"; then
                 should_release=true
                 break

--- a/.github/workflows/_check-release-eligibility.yml
+++ b/.github/workflows/_check-release-eligibility.yml
@@ -19,7 +19,7 @@ on:
     outputs:
       should-release:
         description: If should release or not
-        value: ${{ jobs.check-release-eligibility.should-release }}
+        value: ${{ steps.set-output.outputs.should-release }}
 
 permissions:
   contents: read

--- a/.github/workflows/_check-release-eligibility.yml
+++ b/.github/workflows/_check-release-eligibility.yml
@@ -22,7 +22,6 @@ on:
         value: ${{ jobs.check-release-eligibility.outputs.should-release }}
 
 permissions:
-  contents: read
   pull-requests: read
 
 jobs:

--- a/.github/workflows/_check-release-eligibility.yml
+++ b/.github/workflows/_check-release-eligibility.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     if: inputs.is-release-branch || inputs.force-release
     outputs:
-      should-release: ${{ steps.set-output.output.should-release }}
+      should-release: ${{ steps.set-output.outputs.should-release }}
     steps:
       - name: Force release override
         id: force

--- a/.github/workflows/_check-release-eligibility.yml
+++ b/.github/workflows/_check-release-eligibility.yml
@@ -19,7 +19,7 @@ on:
     outputs:
       should-release:
         description: If should release or not
-        value: ${{ steps.set-output.outputs.should-release }}
+        value: ${{ jobs.check-release-eligibility.outputs.should-release }}
 
 permissions:
   contents: read
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     if: inputs.is-release-branch || inputs.force-release
     outputs:
-      should-release: ${{ steps.set-output.outputs.should-release }}
+      should-release: ${{ steps.set-output.output.should-release }}
     steps:
       - name: Force release override
         id: force

--- a/.github/workflows/_check-release-eligibility.yml
+++ b/.github/workflows/_check-release-eligibility.yml
@@ -1,0 +1,87 @@
+name: check-release-eligibility
+
+on:
+  workflow_call:
+    inputs:
+      is-release-branch:
+        description: "If its a release branch or not. eg main would be is-release-branch=true"
+        type: boolean
+        required: true
+      force-release:
+        description: "Force a release regardless of PR labels"
+        type: boolean
+        required: false
+        default: false
+    secrets:
+      GITHUB_ACCESS_TOKEN:
+        description: "(ie: GITHUB_TOKEN) GitHub token"
+        required: true
+    outputs:
+      should-release:
+        description: If should release or not
+        value: ${{ jobs.check-release-eligibility.should-release }}
+
+permissions:
+  contents: read
+
+jobs:
+  check-release-eligibility:
+    runs-on: ubuntu-latest
+    if: inputs.is-release-branch || inputs.force-release
+    outputs:
+      should-release: ${{ steps.set-output.outputs.should-release }}
+    steps:
+      - name: Force release override
+        id: force
+        if: inputs.force-release == true
+        run: echo "should-release=true" >> $GITHUB_OUTPUT
+
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        if: steps.force.outcome != 'success'
+
+      - name: Get last release tag
+        id: last-tag
+        if: steps.force.outcome != 'success'
+        run: |
+          git fetch --tags
+          echo "tag=$(git describe --tags --abbrev=0 || echo '')" >> $GITHUB_OUTPUT
+
+      - name: Get merged PRs since last tag
+        id: prs
+        if: steps.force.outcome != 'success'
+        run: |
+          if [ -z "${{ steps.last-tag.outputs.tag }}" ]; then
+            range=""
+          else
+            range="${{ steps.last-tag.outputs.tag }}..HEAD"
+          fi
+
+          prs=$(git log $range --pretty=format:'%s' | grep -oE '#[0-9]+' | sort -u | tr -d '#')
+          echo "prs=$prs" >> $GITHUB_OUTPUT
+
+      - name: Check PR labels
+        id: check
+        if: steps.force.outcome != 'success'
+        run: |
+          should_release=false
+          if [ -n "${{ steps.prs.outputs.prs }}" ]; then
+            for pr in ${{ steps.prs.outputs.prs }}; do
+              labels=$(gh pr view $pr --json labels --jq '.labels[].name')
+              if ! echo "$labels" | grep -q "no-release"; then
+                should_release=true
+                break
+              fi
+            done
+          fi
+          echo "should-release=$should_release" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_ACCESS_TOKEN }}
+
+      - id: set-output
+        run: |
+          if [ "${{ steps.force.outputs.should-release }}" == "true" ]; then
+            echo "should-release=true" >> $GITHUB_OUTPUT
+          else
+            echo "should-release=${{ steps.check.outputs.should-release }}" >> $GITHUB_OUTPUT
+          fi

--- a/.github/workflows/_check-release-eligibility.yml
+++ b/.github/workflows/_check-release-eligibility.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       is-release-branch:
-        description: "If its a release branch or not. eg main would be is-release-branch=true"
+        description: "If this is a release branch (e.g., main)"
         type: boolean
         required: true
       force-release:
@@ -14,74 +14,55 @@ on:
         default: false
     secrets:
       GITHUB_ACCESS_TOKEN:
-        description: "(ie: GITHUB_TOKEN) GitHub token"
+        description: "GitHub token"
         required: true
     outputs:
       should-release:
-        description: If should release or not
+        description: "Boolean indicating if release should happen"
         value: ${{ jobs.check-release-eligibility.outputs.should-release }}
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   check-release-eligibility:
     runs-on: ubuntu-latest
-    if: inputs.is-release-branch || inputs.force-release
     outputs:
       should-release: ${{ steps.set-output.outputs.should-release }}
     steps:
-      - name: Force release override
-        id: force
-        if: inputs.force-release == true
-        run: echo "should-release=true" >> $GITHUB_OUTPUT
-
-      - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        if: steps.force.outcome != 'success'
-
-      - name: Get last release tag
-        id: last-tag
-        if: steps.force.outcome != 'success'
-        run: |
-          git fetch --tags
-          echo "tag=$(git describe --tags --abbrev=0 || echo '')" >> $GITHUB_OUTPUT
-
-      - name: Get merged PRs since last tag
-        id: prs
-        if: steps.force.outcome != 'success'
-        run: |
-          if [ -z "${{ steps.last-tag.outputs.tag }}" ]; then
-            range=""
-          else
-            range="${{ steps.last-tag.outputs.tag }}..HEAD"
-          fi
-
-          prs=$(git log $range --pretty=format:'%s' | grep -oE '#[0-9]+' | sort -u | tr -d '#')
-          echo "prs=$prs" >> $GITHUB_OUTPUT
-
-      - name: Check PR labels
-        id: check
-        if: steps.force.outcome != 'success'
+      - name: Determine release eligibility
+        id: set-output
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_ACCESS_TOKEN }}
         run: |
           should_release=false
-          if [ -n "${{ steps.prs.outputs.prs }}" ]; then
-            for pr in ${{ steps.prs.outputs.prs }}; do
-              labels=$(gh pr view $pr --json labels --jq '.labels[].name')
-              if ! echo "$labels" | grep -q "no-release"; then
+
+          if [ "${{ inputs.force-release }}" == "true" ]; then
+            # Force release overrides everything
+            should_release=true
+          elif [ "${{ inputs.is-release-branch }}" == "true" ]; then
+            # Get merged PRs since last release tag
+            LAST_TAG=$(gh api repos/${GITHUB_REPOSITORY}/tags --jq '.[0].name' --silent)
+            if [ -z "$LAST_TAG" ]; then
+              RANGE="$GITHUB_SHA"
+            else
+              RANGE="$LAST_TAG..$GITHUB_SHA"
+            fi
+
+            # Get commits in range and their associated PRs
+            PRS=$(gh api repos/${GITHUB_REPOSITORY}/commits \
+              -f sha="$GITHUB_SHA" \
+              --jq '.[] | select(.commit.message | test("#[0-9]+")) | .commit.message' \
+              --silent | grep -oE '#[0-9]+' | sort -u | tr -d '#')
+
+            for pr in $PRS; do
+              LABELS=$(gh api repos/${GITHUB_REPOSITORY}/pulls/$pr --jq '.labels[].name' --silent)
+              if ! echo "$LABELS" | grep -q "no-release"; then
                 should_release=true
                 break
               fi
             done
           fi
-          echo "should-release=$should_release" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_ACCESS_TOKEN }}
 
-      - id: set-output
-        run: |
-          if [ "${{ steps.force.outputs.should-release }}" == "true" ]; then
-            echo "should-release=true" >> $GITHUB_OUTPUT
-          else
-            echo "should-release=${{ steps.check.outputs.should-release }}" >> $GITHUB_OUTPUT
-          fi
+          echo "should-release=$should_release" >> $GITHUB_OUTPUT

--- a/.github/workflows/_dotnet-build-test-pack-publish-nuget.yml
+++ b/.github/workflows/_dotnet-build-test-pack-publish-nuget.yml
@@ -1,4 +1,4 @@
-name: dotnet-build-test-pack-publish
+name: dotnet-build-test-pack-publish-nuget
 
 on:
   workflow_call:
@@ -97,7 +97,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: ./.github/workflows/_dotnet-publish-package.yml
+    uses: ./.github/workflows/_dotnet-publish-nuget.yml
     with:
       working-directory: ${{ inputs.working-directory }}
       os: ${{ inputs.os }}

--- a/.github/workflows/_dotnet-build-test-pack-publish-nuget.yml
+++ b/.github/workflows/_dotnet-build-test-pack-publish-nuget.yml
@@ -62,6 +62,7 @@ jobs:
   check-release-eligibility:
     uses: ./.github/workflows/_check-release-eligibility.yml
     permissions:
+      contents: read
       pull-requests: read
     with:
       is-release-branch: ${{ inputs.is-release-branch }}

--- a/.github/workflows/_dotnet-build-test-pack-publish-nuget.yml
+++ b/.github/workflows/_dotnet-build-test-pack-publish-nuget.yml
@@ -53,6 +53,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   get-version:
@@ -60,6 +61,8 @@ jobs:
 
   check-release-eligibility:
     uses: ./.github/workflows/_check-release-eligibility.yml
+    permissions:
+      pull-requests: read
     with:
       is-release-branch: ${{ inputs.is-release-branch }}
       force-release: ${{ inputs.force-release }}

--- a/.github/workflows/_dotnet-build-test-pack-publish.yml
+++ b/.github/workflows/_dotnet-build-test-pack-publish.yml
@@ -32,7 +32,7 @@ on:
         type: string
         default: unittests
       is-release-branch:
-        description: "If its a release branch or not. eg main would be is-release-branch=true"
+        description: 'If its a release branch or not. eg release from main check would be "github.ref==''refs/heads/main''" '
         type: boolean
         required: true
       force-release:
@@ -55,17 +55,6 @@ permissions:
   contents: read
 
 jobs:
-  build-and-test:
-    uses: ./.github/workflows/_dotnet-build-and-test.yml
-    with:
-      working-directory: ${{ inputs.working-directory }}
-      os: ${{ inputs.os }}
-      dotnet-version-matrix: ${{ inputs.dotnet-version-matrix }}
-      dotnet-version: ${{ inputs.dotnet-version }}
-      codecov-slug: ${{ inputs.codecov-slug }}
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
   get-version:
     uses: ./.github/workflows/_version.yml
 
@@ -76,6 +65,17 @@ jobs:
       force-release: ${{ inputs.force-release }}
     secrets:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_ACCESS_TOKEN }}
+
+  build-and-test:
+    uses: ./.github/workflows/_dotnet-build-and-test.yml
+    with:
+      working-directory: ${{ inputs.working-directory }}
+      os: ${{ inputs.os }}
+      dotnet-version-matrix: ${{ inputs.dotnet-version-matrix }}
+      dotnet-version: ${{ inputs.dotnet-version }}
+      codecov-slug: ${{ inputs.codecov-slug }}
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   pack:
     needs:
@@ -94,7 +94,6 @@ jobs:
     needs:
       - pack
       - check-release-eligibility
-    if: needs.check-release-eligibility.outputs.should-release == 'true'
     permissions:
       contents: read
       packages: write
@@ -104,8 +103,8 @@ jobs:
       os: ${{ inputs.os }}
       dotnet-version: ${{ inputs.dotnet-version }}
       package-artifact-name: "packages"
-      upload-to-github: ${{ !inputs.is-release-branch }}
-      upload-to-nuget: ${{ inputs.is-release-branch }}
+      upload-to-github: ${{ !inputs.is-release-branch && needs.check-release-eligibility.outputs.should-release != 'true' }}
+      upload-to-nuget: ${{ needs.check-release-eligibility.outputs.should-release == 'true' }}
     secrets:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_ACCESS_TOKEN }}
       NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/_dotnet-build-test-pack-publish.yml
+++ b/.github/workflows/_dotnet-build-test-pack-publish.yml
@@ -31,10 +31,15 @@ on:
         required: false
         type: string
         default: unittests
-      is-release:
-        description: "If its a release branch or not. eg main would be is-release=true"
+      is-release-branch:
+        description: "If its a release branch or not. eg main would be is-release-branch=true"
         type: boolean
         required: true
+      force-release:
+        description: "Force a release regardless of PR labels"
+        type: boolean
+        required: false
+        default: false
     secrets:
       GITHUB_ACCESS_TOKEN:
         description: "(ie: GITHUB_TOKEN) GitHub token"
@@ -64,6 +69,14 @@ jobs:
   get-version:
     uses: ./.github/workflows/_version.yml
 
+  check-release-eligibility:
+    uses: ./.github/workflows/_check-release-eligibility.yml
+    with:
+      is-release-branch: ${{ inputs.is-release-branch }}
+      force-release: ${{ inputs.force-release }}
+    secrets:
+      GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_ACCESS_TOKEN }}
+
   pack:
     needs:
       - build-and-test
@@ -75,10 +88,13 @@ jobs:
       dotnet-version: ${{ inputs.dotnet-version }}
       package-version: ${{ needs.get-version.outputs.version }}
       package-artifact-name: "packages"
-      add-assembly-version: ${{ inputs.is-release }}
+      add-assembly-version: ${{ inputs.is-release-branch }}
 
   publish:
-    needs: pack
+    needs:
+      - pack
+      - check-release-eligibility
+    if: needs.check-release-eligibility.outputs.should-release == 'true'
     permissions:
       contents: read
       packages: write
@@ -88,8 +104,8 @@ jobs:
       os: ${{ inputs.os }}
       dotnet-version: ${{ inputs.dotnet-version }}
       package-artifact-name: "packages"
-      upload-to-github: ${{ !inputs.is-release }}
-      upload-to-nuget: ${{ inputs.is-release }}
+      upload-to-github: ${{ !inputs.is-release-branch }}
+      upload-to-nuget: ${{ inputs.is-release-branch }}
     secrets:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_ACCESS_TOKEN }}
       NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
@@ -98,7 +114,8 @@ jobs:
     needs:
       - publish
       - get-version
-    if: ${{ inputs.is-release }}
+      - check-release-eligibility
+    if: needs.check-release-eligibility.outputs.should-release == 'true'
     permissions:
       contents: write
     uses: ./.github/workflows/_github-tag-and-release.yml

--- a/.github/workflows/_dotnet-publish-nuget.yml
+++ b/.github/workflows/_dotnet-publish-nuget.yml
@@ -1,4 +1,4 @@
-name: dotnet-publish-package
+name: dotnet-publish-nuget
 
 on:
   workflow_call:

--- a/.github/workflows/example-nuget-packages.yml
+++ b/.github/workflows/example-nuget-packages.yml
@@ -16,12 +16,14 @@ on:
 permissions:
   contents: read
   packages: write
+  pull-requests: read
 
 jobs:
   ci-cd:
     permissions:
       contents: write
       packages: write
+      pull-requests: read
     uses: ./.github/workflows/_dotnet-build-test-pack-publish-nuget.yml
     with:
       working-directory: "./examples/NugetPackages"

--- a/.github/workflows/example-nuget-packages.yml
+++ b/.github/workflows/example-nuget-packages.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:   # 👈 allow manual trigger here too
+  workflow_dispatch: # 👈 manual trigger here to release
     inputs:
       force-release:
         description: "Force a release regardless of PR labels"
@@ -31,6 +31,6 @@ jobs:
       dotnet-version-matrix: '[{ "dotnet-version": "9.0.x", "framework": "net9.0" }]'
       dotnet-version: 9.0.x
       is-release-branch: false   # ${{ github.ref == 'refs/heads/main' }}
-      force-release: ${{ inputs.force-release }}
+      force-release: ${{ github.event.inputs.force-release || false }}
     secrets:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/example-nuget-packages.yml
+++ b/.github/workflows/example-nuget-packages.yml
@@ -5,6 +5,13 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:   # 👈 allow manual trigger here too
+    inputs:
+      force-release:
+        description: "Force a release regardless of PR labels"
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -21,7 +28,8 @@ jobs:
       os: ubuntu-latest
       dotnet-version-matrix: '[{ "dotnet-version": "9.0.x", "framework": "net9.0" }]'
       dotnet-version: 9.0.x
-      is-release: false
-      #is-release: ${{ github.ref == 'refs/heads/main' }}
+      is-release-branch: false
+      #is-release-branch: ${{ github.ref == 'refs/heads/main' }}
+      force-release: ${{ inputs.force-release }}
     secrets:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/example-nuget-packages.yml
+++ b/.github/workflows/example-nuget-packages.yml
@@ -31,6 +31,6 @@ jobs:
       is-release-branch: false
       #is-release-branch: ${{ github.ref == 'refs/heads/main' }}
       #force-release: ${{ inputs.force-release }}
-      force-release:: false
+      force-release: false
     secrets:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/example-nuget-packages.yml
+++ b/.github/workflows/example-nuget-packages.yml
@@ -30,6 +30,7 @@ jobs:
       dotnet-version: 9.0.x
       is-release-branch: false
       #is-release-branch: ${{ github.ref == 'refs/heads/main' }}
-      force-release: ${{ inputs.force-release }}
+      #force-release: ${{ inputs.force-release }}
+      force-release:: false
     secrets:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/example-nuget-packages.yml
+++ b/.github/workflows/example-nuget-packages.yml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: write
       packages: write
-    uses: ./.github/workflows/_dotnet-build-test-pack-publish.yml
+    uses: ./.github/workflows/_dotnet-build-test-pack-publish-nuget.yml
     with:
       working-directory: "./examples/NugetPackages"
       os: ubuntu-latest

--- a/.github/workflows/example-nuget-packages.yml
+++ b/.github/workflows/example-nuget-packages.yml
@@ -30,9 +30,7 @@ jobs:
       os: ubuntu-latest
       dotnet-version-matrix: '[{ "dotnet-version": "9.0.x", "framework": "net9.0" }]'
       dotnet-version: 9.0.x
-      is-release-branch: false
-      #is-release-branch: ${{ github.ref == 'refs/heads/main' }}
-      #force-release: ${{ inputs.force-release }}
-      force-release: false
+      is-release-branch: false   # ${{ github.ref == 'refs/heads/main' }}
+      force-release: ${{ inputs.force-release }}
     secrets:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### :spiral_notepad: Description

release => publish package to nuget, create a git tag and do a github release with release change notes

on nuget package ci-cd pipeline
* allow manual force-release trigger of ci-cd pipeline to release
* check prs into main since last git release tag, and if any don't have the "no-release" label, then release
* if all prs merged into main since the last release have "no-release" label, then do not release

### :white_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable -->

- [ ] Linked to any related issues in the PR description
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Breaking changes were made
